### PR TITLE
Refactored reset_sequence_num custom logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SequenceId is compatible with Active Record  **3.0**.
 
     bundle install
 
-    rails generate sequenceid <parent resource> <nested resource> #eg rails generate sequenceid Company Invoice 
+    rails generate sequenceid <parent resource> <nested resource> #eg rails generate sequenceid company invoice 
 
     rake db:migrate
 

--- a/lib/generators/sequenceid/sequenceid_generator.rb
+++ b/lib/generators/sequenceid/sequenceid_generator.rb
@@ -44,7 +44,7 @@ class SequenceidGenerator < ActiveRecord::Generators::Base
 
   def do_work
     #create migration and run migrate script
-    migration_template "migration.rb", "db/migrate/add_sequence_num_to_#{@nested_resource.to_s.downcase.pluralize}"
+    migration_template "migration.rb", "db/migrate/add_sequence_num_to_#{@nested_resource.to_s.downcase.pluralize}.rb"
     #inject into model class module includeA
     @model_path ||= File.join("app", "models", "#{@nested_resource.to_s.underscore}.rb")
     inject_into_class(@model_path,@nested_resource,"\tsequenceid :#{@parent_resource.to_s.downcase.to_sym} , :#{@nested_resource.to_s.downcase.pluralize.to_sym}\n")

--- a/lib/sequenceid/model_adapters/sequenceid_logic.rb
+++ b/lib/sequenceid/model_adapters/sequenceid_logic.rb
@@ -29,13 +29,15 @@ module Sequenceid
 
       def reset_sequence_num
         @save_counter ||= 1
-        if new_record? && valid? && @save_counter < 3 
-          logger.info "SEQUENCE_ID_GEM:: attempt number #{@save_counter} of a max 2"
-          self.sequence_num = relation_sequence.reorder("id").last.try(:sequence_num) + 1 # REORDER to override order clause if default scope applied on nested_resource
-          @save_counter    += 1
-          save
-        else
-          raise
+        if new_record? && valid?
+          if @save_counter < 3
+            logger.info "SEQUENCE_ID_GEM:: attempt number #{@save_counter} of a max 2"
+            self.sequence_num=relation_sequence.order("id").last.try(:sequence_num) + 1
+            @save_counter += 1
+            save
+          else
+            raise
+          end
         end
       end
 


### PR DESCRIPTION
Database_cleaner gem rollback transactions while cleaning the data triggers the reset_sequence_num method raising RuntimeError. 
Moreover, Migration files were missing the extension(.rb).