### PR TITLE
Feature/change activerecord base to applicationrecord in sti parent class

### DIFF
--- a/lib/sequenceid/model_adapters/sequenceid_logic.rb
+++ b/lib/sequenceid/model_adapters/sequenceid_logic.rb
@@ -49,7 +49,7 @@ module Sequenceid
       #for Single Table Inheritance, we need to keep going up the hierarchy until we reach the class right below ActiveRecord. Probably
       #ought to fix this for extreme cases where models are based on a different hierarchy (monkey patch with your base model class)
       def get_sti_parent_class(klass)
-        return klass if (klass.superclass == ActiveRecord::Base || klass.superclass == Object || klass.superclass.nil?)
+        return klass if (klass.superclass == ApplicationRecord || klass.superclass == Object || klass.superclass.nil?)
         get_sti_parent_class(klass.superclass)
       end
 

--- a/lib/sequenceid/version.rb
+++ b/lib/sequenceid/version.rb
@@ -1,3 +1,3 @@
 module Sequenceid
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
- Used ApplicationRecord instead of ActiveRecord::Base in the get_sti_parent_class(klass) method.
- That is because Rails 5 introduced ApplicationRecord which all models should inherit from instead of ActiveRecord.
- For more info: https://blog.bigbinary.com/2015/12/28/application-record-in-rails-5.html