### PR TITLE
Fix generator warning for belongs to

### DIFF
--- a/lib/generators/sequenceid/sequenceid_generator.rb
+++ b/lib/generators/sequenceid/sequenceid_generator.rb
@@ -32,7 +32,7 @@ class SequenceidGenerator < ActiveRecord::Generators::Base
         exit
       end
       #if not belongs to
-      if(!@parent_resource.new.respond_to? @nested_resource.to_s.downcase.pluralize)
+      if(!@parent_resource.new.respond_to? @nested_resource.to_s.underscore.pluralize)
         exit unless yes?("ERROR: The resource #{nested_resource_s} should have a belongs to association with #{parent_resource_s}, do you still want to continue (risky)?")
       end
 
@@ -44,7 +44,7 @@ class SequenceidGenerator < ActiveRecord::Generators::Base
 
   def do_work
     #create migration and run migrate script
-    migration_template "migration.rb", "db/migrate/add_sequence_num_to_#{@nested_resource.to_s.downcase.pluralize}.rb"
+    migration_template "migration.rb", "db/migrate/add_sequence_num_to_#{@nested_resource.to_s.underscore.pluralize}.rb"
     #inject into model class module includeA
     @model_path ||= File.join("app", "models", "#{@nested_resource.to_s.underscore}.rb")
     inject_into_class(@model_path,@nested_resource,"\tsequenceid :#{@parent_resource.to_s.downcase.to_sym} , :#{@nested_resource.to_s.downcase.pluralize.to_sym}\n")

--- a/lib/generators/sequenceid/template/migration.rb
+++ b/lib/generators/sequenceid/template/migration.rb
@@ -1,6 +1,6 @@
-class AddSequenceNumTo<%= @nested_resource.to_s.downcase.pluralize.camelize %> < ActiveRecord::Migration
+class AddSequenceNumTo<%= @nested_resource.to_s.underscore.pluralize.camelize %> < ActiveRecord::Migration
   <% @parent_resource_name = @parent_resource.to_s.downcase %>
-  <% @nested_resource_name = @nested_resource.to_s.downcase.pluralize %>
+  <% @nested_resource_name = @nested_resource.to_s.underscore.pluralize %>
   def self.up
     add_column :<%= @nested_resource_name %>, :sequence_num, :integer, null: false
     update_sequence_num_values


### PR DESCRIPTION
currently generator looks for nested resource by downcasing the class name.

for `Company` and `CheckoutRequest`
generator looks for belongs_to association for `company` in `CheckoutRequest` but looks for `checkoutrequrests` instead of `checkout_requests` in `Company`